### PR TITLE
Use avhost/docker-matrix-riot in docker run example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ To support this Dockerimage please pledge via [liberapay].
 For starting you need a mapping for the `/data`-directory with
 a `riot.im.conf` file.
 
-    $ docker run -d -v /tmp/data:/data silviof/matrix-riot-docker
+    $ docker run -d -v /tmp/data:/data avhost/docker-matrix-riot
 
 To configure some aspect of the service, this folder can also hold
 a `config.json` file. The riot-web "binary" will generated on every start of


### PR DESCRIPTION
I suppose `avhost/docker-matrix-riot` is the target of building this repo's dockerfile and should be used instead of silviof/matrix-riot-docker here.

(Sorry for the last line change - probably EOL added automatically by github's web editor)