### PR TITLE
Add version file used by riot for update notification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN chmod a+x /start.sh \
     || exit 1 \
     ; \
     mv /riot-web/webapp / ; \
+    echo "$BV_VEC" | tr -d v > /webapp/version ; \
     rm -rf /riot-web ; \
     rm -rf /root/.npm ; \
     rm -rf /tmp/* ; \


### PR DESCRIPTION
This is useful because users are displayed with notifications to reload the page on update, which otherwise is missing, and can lead to strange, silent errors.